### PR TITLE
Fixed minor issue with tilde expansion inside quotes in bash

### DIFF
--- a/bin/database.sh
+++ b/bin/database.sh
@@ -64,17 +64,17 @@ display_credential(){
 }
 
 store_credential(){
-    if [ -d "~/sites/${1}" ]; then
-        if [ -f ~/sites/${1}/.db_pass ]; then 
-            mv ~/sites/${1}/.db_pass ~/sites/${1}/.db_pass.bk
+    if [ -d "$HOME/sites/${1}" ]; then
+        if [ -f $HOME/sites/${1}/.db_pass ]; then 
+            mv $HOME/sites/${1}/.db_pass $HOME/sites/${1}/.db_pass.bk
         fi
-        cat > "~/sites/${1}/.db_pass" << EOT
+        cat > "$HOME/sites/${1}/.db_pass" << EOT
 "Database":"${SQL_DB}"
 "Username":"${SQL_USER}"
 "Password":"$(echo ${SQL_PASS} | tr -d "'")"
 EOT
     else
-        echo "~/sites/${1} not found, abort credential store!"
+        echo "$HOME/sites/${1} not found, abort credential store!"
     fi    
 }
 

--- a/bin/demosite.sh
+++ b/bin/demosite.sh
@@ -38,8 +38,8 @@ domain_filter(){
 }
 
 gen_root_fd(){
-    DOC_FD="~/sites/${1}/"
-    if [ -d "~/sites/${1}" ]; then
+    DOC_FD="$HOME/sites/${1}/"
+    if [ -d "$HOME/sites/${1}" ]; then
         echo -e "[O] The root folder \033[32m${DOC_FD}\033[0m exist."
     else
         echo "Creating - document root."

--- a/bin/domain.sh
+++ b/bin/domain.sh
@@ -28,8 +28,8 @@ check_input(){
 add_domain(){
     check_input ${1}
     docker-compose exec ${CONT_NAME} su -s /bin/bash lsadm -c "cd /usr/local/lsws/conf && domainctl.sh --add ${1}"
-    if [ ! -d "~/sites/${1}" ]; then 
-        mkdir -p ~/sites/${1}/{html,logs,certs}
+    if [ ! -d "$HOME/sites/${1}" ]; then 
+        mkdir -p $HOME/sites/${1}/{html,logs,certs}
     fi
     bash bin/webadmin.sh -r
 }


### PR DESCRIPTION
Bash does not expand ~ when placed within quotes.

There are two ways to solve this,

- use this format: ~"/path"
- use the $HOME env. variable

used the second option for better readability.